### PR TITLE
bug fix: when input object is not a valid JSON object, in - (void)put…

### DIFF
--- a/YTKKeyValueStore/YTKKeyValueStore.m
+++ b/YTKKeyValueStore/YTKKeyValueStore.m
@@ -164,12 +164,12 @@ static NSString *const DROP_TABLE_SQL = @" DROP TABLE '%@' ";
     if ([YTKKeyValueStore checkTableName:tableName] == NO) {
         return;
     }
-    NSError * error;
-    NSData * data = [NSJSONSerialization dataWithJSONObject:object options:0 error:&error];
-    if (error) {
+    if([NSJSONSerialization isValidJSONObject:object] == NO){
         debugLog(@"ERROR, faild to get json data");
         return;
     }
+    NSData * data = [NSJSONSerialization dataWithJSONObject:object options:0 error:nil];
+
     NSString * jsonString = [[NSString alloc] initWithData:data encoding:(NSUTF8StringEncoding)];
     NSDate * createdTime = [NSDate date];
     NSString * sql = [NSString stringWithFormat:UPDATE_ITEM_SQL, tableName];

--- a/YTKKeyValueStoreTests/YTKKeyValueStoreTests.m
+++ b/YTKKeyValueStoreTests/YTKKeyValueStoreTests.m
@@ -10,6 +10,14 @@
 #import <XCTest/XCTest.h>
 #import "YTKKeyValueStore.h"
 
+@interface YTKPersion : NSObject
+@property (nonatomic, strong) NSString *name;
+@end
+
+@implementation YTKPersion
+
+@end
+
 @interface YTKKeyValueStoreTests : XCTestCase
 
 @end
@@ -75,6 +83,16 @@
     [self measureBlock:^{
         // Put the code you want to measure the time of here.
     }];
+}
+
+- (void)testInvalidObject{
+    YTKPersion *person = [YTKPersion new];
+    person.name = @"apple";
+    @try {
+        [_store putObject:person withId:@"1" intoTable:_tableName];
+    } @catch (NSException *exception) {
+        XCTAssert(NO, @"should NOT throw and exception");
+    }
 }
 
 @end


### PR DESCRIPTION
…Object:(id)object withId:(NSString *)objectId intoTable:(NSString *)tableName, do NOT throw an exception